### PR TITLE
Prep for 0.1.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/consul-core

--- a/.github/workflows/test-go-netaddrs.yaml
+++ b/.github/workflows/test-go-netaddrs.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.19'
       - run: go test
   golangci:
     name: lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# WORK IN PROGRESS
-
-This library is still under development and hence subject to breaking changes.
+[![GoDoc](https://pkg.go.dev/github.com/hashicorp/go-netaddrs?status.svg)](https://pkg.go.dev/github.com/hashicorp/go-netaddrs)
 
 ## Summary
 

--- a/cmd/netaddrs/main.go
+++ b/cmd/netaddrs/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -28,7 +27,7 @@ func main() {
 
 	var w io.Writer = os.Stderr
 	if quiet {
-		w = ioutil.Discard
+		w = io.Discard
 	}
 	l := log.New(w, "netaddrs: ", 0)
 	addresses, err := netaddrs.IPAddrs(context.Background(), args[1], logger{l: l})

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hashicorp/go-netaddrs
 
-go 1.17
+go 1.19


### PR DESCRIPTION
* Bump to go 1.19, and fix the ioutil deprecation warning
* Add CODEOWNERS
* Remove WIP from readme
* Add GoDoc badge to README